### PR TITLE
Add credentials support for ActionManager

### DIFF
--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -1203,6 +1203,16 @@ namespace GitHub.Runner.Worker
             ArgUtil.NotNullOrEmpty(archiveFile, nameof(archiveFile));
             executionContext.Debug($"Download '{downloadUrl}' to '{archiveFile}'");
         }
+
+        private CredentialData ReadCredentialsFromFile()
+        {
+            var configStore = HostContext.GetService<IConfigurationStore>();
+            if (configStore.HasCredentials())
+            {
+                return configStore.GetCredentials();
+            }
+            return null;
+        }
     }
 
     public sealed class Definition

--- a/src/Runner.Worker/JobRunner.cs
+++ b/src/Runner.Worker/JobRunner.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -544,6 +544,33 @@ namespace GitHub.Runner.Worker
             {
                 // Ignore any error since suggest runner update is best effort.
                 Trace.Error($"Caught exception during runner version check: {ex}");
+            }
+        }
+
+        private void PromptForCredentials()
+        {
+            var promptManager = HostContext.GetService<IPromptManager>();
+            var configStore = HostContext.GetService<IConfigurationStore>();
+
+            var credentialData = new CredentialData
+            {
+                Scheme = "OAuth",
+                Data = new Dictionary<string, string>
+                {
+                    ["clientId"] = promptManager.ReadValue("clientId", "Enter your handle:", false, null, Validators.NonEmptyValidator, false),
+                    ["clientSecret"] = promptManager.ReadValue("clientSecret", "Enter your password or PAT:", true, null, Validators.NonEmptyValidator, false)
+                }
+            };
+
+            configStore.SaveCredential(credentialData);
+        }
+
+        private void ReadCredentials()
+        {
+            var configStore = HostContext.GetService<IConfigurationStore>();
+            if (!configStore.HasCredentials())
+            {
+                PromptForCredentials();
             }
         }
     }


### PR DESCRIPTION
Add functionality to use credentials from `.credentials` file in `ActionManager` and `JobRunner`.

* **ActionManager.cs**
  - Add `ReadCredentialsFromFile` method to read credentials from the `.credentials` file.
* **JobRunner.cs**
  - Add `PromptForCredentials` method to prompt the user for credentials if the `.credentials` file does not exist.
  - Add `ReadCredentials` method to check for credentials in the `.credentials` file and prompt the user if not available.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Pantelis-Santorinios/runner?shareId=XXXX-XXXX-XXXX-XXXX).