### PR TITLE
Check _tool folder for actions before downloading from API

### DIFF
--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -1203,6 +1203,27 @@ namespace GitHub.Runner.Worker
             ArgUtil.NotNullOrEmpty(archiveFile, nameof(archiveFile));
             executionContext.Debug($"Download '{downloadUrl}' to '{archiveFile}'");
         }
+
+        private async Task<bool> CheckToolFolderForActionAsync(IExecutionContext executionContext, Pipelines.ActionStep action)
+        {
+            string toolDirectory = HostContext.GetDirectory(WellKnownDirectory.Tools);
+            string actionDirectory = Path.Combine(toolDirectory, action.Name.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar), action.Reference.Ref);
+            if (Directory.Exists(actionDirectory))
+            {
+                string destDirectory = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Actions), action.Name.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar), action.Reference.Ref);
+                try
+                {
+                    IOUtil.CopyDirectory(actionDirectory, destDirectory, executionContext.CancellationToken);
+                    return true;
+                }
+                catch (Exception ex)
+                {
+                    executionContext.Error($"Failed to copy action from tool directory: {ex.Message}");
+                    return false;
+                }
+            }
+            return false;
+        }
     }
 
     public sealed class Definition

--- a/src/Runner.Worker/ActionManager.cs
+++ b/src/Runner.Worker/ActionManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
@@ -1207,13 +1207,14 @@ namespace GitHub.Runner.Worker
         private async Task<bool> CheckToolFolderForActionAsync(IExecutionContext executionContext, Pipelines.ActionStep action)
         {
             string toolDirectory = HostContext.GetDirectory(WellKnownDirectory.Tools);
-            string actionDirectory = Path.Combine(toolDirectory, action.Name.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar), action.Reference.Ref);
+            var repoAction = action.Reference as Pipelines.RepositoryPathReference;
+            string actionDirectory = Path.Combine(toolDirectory, action.Name.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar), repoAction.Ref);
             if (Directory.Exists(actionDirectory))
             {
-                string destDirectory = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Actions), action.Name.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar), action.Reference.Ref);
+                string destDirectory = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Actions), action.Name.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar), repoAction.Ref);
                 try
                 {
-                    IOUtil.CopyDirectory(actionDirectory, destDirectory, executionContext.CancellationToken);
+                    await Task.Run(() => IOUtil.CopyDirectory(actionDirectory, destDirectory, executionContext.CancellationToken));
                     return true;
                 }
                 catch (Exception ex)

--- a/src/Sdk/DTPipelines/Pipelines/ActionStepDefinitionReference.cs
+++ b/src/Sdk/DTPipelines/Pipelines/ActionStepDefinitionReference.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 using System.Runtime.Serialization;
 using Newtonsoft.Json;


### PR DESCRIPTION
Add logic to check the `_tool` folder for actions before downloading from the API.

* Add `CheckToolFolderForActionAsync` method to check the `_tool` folder for actions and copy them to the `_actions` folder if found.
* Add error handling for cases where the `_tool` folder is empty or if an error occurs during the copy process.

