### PR TITLE
Fix async methods to run asynchronously

### DIFF
--- a/src/Runner.Common/ActionsRunServer.cs
+++ b/src/Runner.Common/ActionsRunServer.cs
@@ -38,10 +38,10 @@ namespace GitHub.Runner.Common
             }
         }
 
-        public Task<AgentJobRequestMessage> GetJobMessageAsync(string id, CancellationToken cancellationToken)
+        public async Task<AgentJobRequestMessage> GetJobMessageAsync(string id, CancellationToken cancellationToken)
         {
             CheckConnection();
-            var jobMessage = RetryRequest<AgentJobRequestMessage>(async () =>
+            var jobMessage = await RetryRequest<AgentJobRequestMessage>(async () =>
                                                     {
                                                         return await _actionsRunServerClient.GetJobMessageAsync(id, cancellationToken);
                                                     }, cancellationToken);

--- a/src/Runner.Common/RunnerServer.cs
+++ b/src/Runner.Common/RunnerServer.cs
@@ -1,4 +1,4 @@
-﻿using GitHub.DistributedTask.WebApi;
+using GitHub.DistributedTask.WebApi;
 using System;
 using System.Collections.Generic;
 using System.Threading;
@@ -330,7 +330,7 @@ namespace GitHub.Runner.Common
 
         public async Task DownloadActionIfNotExists(string actionName, Uri actionUri)
         {
-            if (!ActionExistsInToolDirectory(actionName))
+            if (!await Task.Run(() => ActionExistsInToolDirectory(actionName)))
             {
                 // Logic to download the action from the provided URI
                 // This is a placeholder and should be replaced with actual download logic


### PR DESCRIPTION
Add 'await' operators to async methods in `ActionsRunServer.cs` and `RunnerServer.cs` to ensure asynchronous execution.

* **ActionsRunServer.cs**
  - Change `GetJobMessageAsync` method to use 'await' operator for `RetryRequest` call.
  - Ensure `GetJobMessageAsync` method runs asynchronously.

* **RunnerServer.cs**
  - Change `DownloadActionIfNotExists` method to use 'await' operator for `ActionExistsInToolDirectory` call.
  - Ensure `DownloadActionIfNotExists` method runs asynchronously.

